### PR TITLE
Expanded types bugs

### DIFF
--- a/demo/lit-app/custom-elements.json
+++ b/demo/lit-app/custom-elements.json
@@ -162,9 +162,12 @@
               "kind": "field",
               "name": "data",
               "type": {
-                "text": "DataObject | undefined"
+                "text": "{\n    // The name.\n    name?: string,\n    /** The type. */\n    type?: string,\n    /** The value. */\n    value?: number,\n  } | undefined"
               },
-              "description": "This is data object"
+              "description": "This is data object",
+              "expandedType": {
+                "text": "{\n    // The name.\n    name??: string,\n    /** The type. */\n    type?: string,\n    /** The value. */\n    value?: number,\n  } | undefined"
+              }
             },
             {
               "kind": "field",
@@ -540,29 +543,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/radio-group/radio-group.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "RadioGroup",
-          "declaration": {
-            "name": "RadioGroup",
-            "module": "src/radio-group/radio-group.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "radio-group",
-          "declaration": {
-            "name": "RadioGroup",
-            "module": "/src/radio-group/RadioGroup.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/radio-button/radio-button.ts",
       "declarations": [],
       "exports": [
@@ -580,6 +560,29 @@
           "declaration": {
             "name": "RadioButton",
             "module": "/src/radio-button/RadioButton.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/radio-group/radio-group.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "RadioGroup",
+          "declaration": {
+            "name": "RadioGroup",
+            "module": "src/radio-group/radio-group.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "radio-group",
+          "declaration": {
+            "name": "RadioGroup",
+            "module": "/src/radio-group/RadioGroup.js"
           }
         }
       ]

--- a/demo/lit-app/src/radio-group/RadioGroup.ts
+++ b/demo/lit-app/src/radio-group/RadioGroup.ts
@@ -101,7 +101,14 @@ export class RadioGroup extends LitElement {
 
   /** This is data object */
   @property({ attribute: false })
-  data?: DataObject;
+  data?: {
+    // The name.
+    name?: string,
+    /** The type. */
+    type?: string,
+    /** The value. */
+    value?: number,
+  };
 
   /** This is a test for options from an object */
   @property({ attribute: 'complex-union' })

--- a/packages/expanded-types/CHANGELOG.md
+++ b/packages/expanded-types/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.4
+
+- Updated to prevent errors when object types have comments
+- Add optional chaining when evaluating types in case they return `null` or undefined
+
 ## 1.1.3
 
 - Added check for missing value

--- a/packages/expanded-types/package.json
+++ b/packages/expanded-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cem-plugin-expanded-types",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A CEM Analyzer plugin to add expanded TypeScript types to the Custom Elements Manifest",
   "main": "index.js",
   "module": "index.js",

--- a/packages/expanded-types/src/cem-plugin.ts
+++ b/packages/expanded-types/src/cem-plugin.ts
@@ -97,9 +97,11 @@ function getObjectTypes(fileName: string, typeName: string) {
     ),
   ];
   parts.forEach((part) => {
+    const cleanPart = part
+      .replace(/\/\*[\s\S]*?\*\/|(?<=[^:])\/\/.*|^\/\/.*/g, "");
     typeName = typeName.replace(
-      new RegExp(part, "g"),
-      getExpandedType(fileName, part)
+      new RegExp(cleanPart, "g"),
+      getExpandedType(fileName, cleanPart)
     );
   });
   return typeName;
@@ -133,7 +135,7 @@ function parseFileTypes(node: any) {
 }
 
 function setEnumTypes(node: any) {
-  const name = node.name.escapedText;
+  const name = node.name?.escapedText;
   const shortText =
     node.members?.map((mem: any) => mem.initializer?.text).join(" | ") || "";
 
@@ -147,7 +149,7 @@ function setBasicUnionTypes(node: any) {
       ?.map((type: any) => {
         let value = type?.literal?.text;
         if (!value && type?.typeName?.escapedText) {
-          value = getExpandedType(currentFilename, type.typeName.escapedText);
+          value = getExpandedType(currentFilename, type.typeName?.escapedText);
           return value;
         }
         return typeof value === "string" ? `'${value}'` : value;

--- a/packages/expanded-types/src/cem-plugin.ts
+++ b/packages/expanded-types/src/cem-plugin.ts
@@ -97,6 +97,7 @@ function getObjectTypes(fileName: string, typeName: string) {
     ),
   ];
   parts.forEach((part) => {
+    // remove comments from object
     const cleanPart = part
       .replace(/\/\*[\s\S]*?\*\/|(?<=[^:])\/\/.*|^\/\/.*/g, "");
     typeName = typeName.replace(


### PR DESCRIPTION

- Updated to prevent errors when object types have comments (#19)
- Add optional chaining when evaluating types in case they return `null` or undefined (#18)