### PR TITLE
update SolidJS base props

### DIFF
--- a/packages/solidjs-integration/CHANGELOG.md
+++ b/packages/solidjs-integration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.6.0
+
+- Added `innerHTML` and `textContent` attributes
+- Removed `htmlFor` attribute as it is not used in SolidJS JSX
+
 ## 1.5.0
 
 - Added additional default attributes - `dir`, `exportparts`, `htmlFor`, `hidden`, `id`, `lang`, `ref`, `tabIndex`, `title`, and `translate`.

--- a/packages/solidjs-integration/package.json
+++ b/packages/solidjs-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-element-solidjs-integration",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Tools for integrating custom elements into SolidJS",
   "main": "index.js",
   "module": "index.js",

--- a/packages/solidjs-integration/src/type-generator.ts
+++ b/packages/solidjs-integration/src/type-generator.ts
@@ -106,12 +106,12 @@ type BaseProps = {
   dir?: "ltr" | "rtl";
   /** Contains a space-separated list of the part names of the element that should be exposed on the host element. */
   exportparts?: string;
-  /** For <label> and <output>, lets you associate the label with some control. */
-  htmlFor?: string;
   /** Specifies whether the element should be hidden. */
   hidden?: boolean | string;
   /** A unique identifier for the element. */
-  id?: string;
+  id?: string;  
+  /** Sets the HTML or XML markup contained within the element. */
+  innerHTML?: string;
   /** Specifies the language of the element. */
   lang?: string;
   /** Contains a space-separated list of the part names of the element. Part names allows CSS to select and style specific elements in a shadow tree via the ::part pseudo-element. */
@@ -123,7 +123,9 @@ type BaseProps = {
   /** Prop for setting inline styles */
   style?: JSX.CSSProperties;
   /** Overrides the default Tab button behavior. Avoid using values other than -1 and 0. */
-  tabIndex?: number;
+  tabIndex?: number;  
+  /** Sets the text content of the element */
+  textContent?: number;
   /** Specifies the tooltip text for the element. */
   title?: string;
   /** Passing 'no' excludes the element content from being translated. */


### PR DESCRIPTION
- Added `innerHTML` and `textContent` attributes
- Removed `htmlFor` attribute as it is not used in SolidJS JSX