### PR TITLE
custom-element-jet-brains-integration: Improve JS property and event generation

### DIFF
--- a/packages/jet-brains-integration/src/types.d.ts
+++ b/packages/jet-brains-integration/src/types.d.ts
@@ -59,6 +59,7 @@ export interface JsProperties {
 
 export interface WebTypeEvent {
   name: string;
+  type?: string
   description?: string;
 }
 

--- a/packages/jet-brains-integration/src/types.d.ts
+++ b/packages/jet-brains-integration/src/types.d.ts
@@ -41,12 +41,19 @@ export interface WebTypeAttribute {
   value: WebTypeValue;
 }
 
+export interface WebTypeJsProperty {
+  name: string;
+  description?: string;
+  type?: string;
+  default?: string;
+}
+
 export interface WebTypeValue {
   type?: string | string[];
 }
 
 export interface JsProperties {
-  properties: WebTypeAttribute[];
+  properties: WebTypeJsProperty[];
   events: WebTypeEvent[];
 }
 

--- a/packages/jet-brains-integration/src/web-types-generator.ts
+++ b/packages/jet-brains-integration/src/web-types-generator.ts
@@ -3,7 +3,6 @@ import type {
   JsProperties,
   Options,
   Reference,
-  WebTypeAttribute,
   WebTypeCssProperty,
   WebTypeElement,
   WebTypeEvent,
@@ -56,17 +55,14 @@ export function getTagList(
           description: slot.description,
         };
       }),
-      js: getJsProperties(component, options.typesSrc),
+      js: getJsProperties(component),
     };
   });
 }
 
-function getJsProperties(
-  component: Component,
-  typesSrc?: string
-): JsProperties {
+function getJsProperties(component: Component): JsProperties {
   return {
-    properties: getWebTypeProperties(component, typesSrc),
+    properties: getWebTypeProperties(component),
     events: getWebTypeEvents(component),
   };
 }
@@ -82,10 +78,7 @@ function isWebTypeProperty(field: schema.ClassField): boolean {
   return field.static !== true && (field.privacy === 'public' || field.privacy === undefined)
 }
 
-function getWebTypeProperties(
-  component: Component,
-  typesSrc = "types"
-): WebTypeJsProperty[] {
+function getWebTypeProperties(component: Component,): WebTypeJsProperty[] {
   return (
     (component.members?.filter((member) => member.kind === 'field') as schema.ClassField[])
       .filter(isWebTypeProperty)

--- a/packages/jet-brains-integration/src/web-types-generator.ts
+++ b/packages/jet-brains-integration/src/web-types-generator.ts
@@ -86,8 +86,8 @@ function getWebTypeProperties(
   typesSrc = 'type'
 ): WebTypeJsProperty[] {
   return (
-    (component.members?.filter((member) => member.kind === 'field') as schema.ClassField[])
-      .filter(isPublicProperty)
+    (component.members?.filter((member) => member.kind === 'field') as schema.ClassField[] | undefined)
+      ?.filter(isPublicProperty)
       .map((field) => {
         return {
           name: field.name,

--- a/packages/jet-brains-integration/src/web-types-generator.ts
+++ b/packages/jet-brains-integration/src/web-types-generator.ts
@@ -83,28 +83,16 @@ function isPublicProperty(field: schema.ClassField): boolean {
 
 function getWebTypeProperties(
   component: Component,
-  typesSrc?: string
+  typesSrc = 'type'
 ): WebTypeJsProperty[] {
   return (
     (component.members?.filter((member) => member.kind === 'field') as schema.ClassField[])
       .filter(isPublicProperty)
       .map((field) => {
-        let type: string | undefined = field.type?.text;
-        if (typesSrc) {
-          if (typesSrc in field) {
-            type = (field as any)[typesSrc]?.text;
-          } else {
-            logYellow(
-                `[jet-brains-web-type-generator] - Could not find custom types source CEM property ` +
-                `"${typesSrc}" for property "${field.name}" of custom element "${component.tagName}". ` +
-                `Falling back to "type".`
-            )
-          }
-        }
         return {
           name: field.name,
           description: field.description,
-          type: type,
+          type: (field as any)[typesSrc]?.text || field.type?.text
         }
       }) || []
   );

--- a/packages/jet-brains-integration/src/web-types-generator.ts
+++ b/packages/jet-brains-integration/src/web-types-generator.ts
@@ -69,10 +69,9 @@ function getJsProperties(component: Component): JsProperties {
 
 /**
  * @param field The Custom Elements Manifest class field to evaluate
- * @return Whether the Custom Elements Manifest class field is considered a JS property by JetBrains
- * Web Types
+ * @return Whether the Custom Elements Manifest class field is a public property
  */
-function isWebTypeProperty(field: schema.ClassField): boolean {
+function isPublicProperty(field: schema.ClassField): boolean {
   // It appears that JetBrains Web Types assumes that all properties are public (TS only) and not
   // static.
   return field.static !== true && (field.privacy === 'public' || field.privacy === undefined)
@@ -81,7 +80,7 @@ function isWebTypeProperty(field: schema.ClassField): boolean {
 function getWebTypeProperties(component: Component,): WebTypeJsProperty[] {
   return (
     (component.members?.filter((member) => member.kind === 'field') as schema.ClassField[])
-      .filter(isWebTypeProperty)
+      .filter(isPublicProperty)
       .map((field) => {
         return {
           name: field.name,

--- a/packages/jet-brains-integration/src/web-types-generator.ts
+++ b/packages/jet-brains-integration/src/web-types-generator.ts
@@ -62,8 +62,8 @@ export function getTagList(
 }
 
 function getJsProperties(
-    component: Component,
-    typesSrc?: string
+  component: Component,
+  typesSrc?: string
 ): JsProperties {
   return {
     properties: getWebTypeProperties(component, typesSrc),
@@ -82,8 +82,8 @@ function isPublicProperty(field: schema.ClassField): boolean {
 }
 
 function getWebTypeProperties(
-    component: Component,
-    typesSrc?: string
+  component: Component,
+  typesSrc?: string
 ): WebTypeJsProperty[] {
   return (
     (component.members?.filter((member) => member.kind === 'field') as schema.ClassField[])

--- a/packages/jet-brains-integration/src/web-types-generator.ts
+++ b/packages/jet-brains-integration/src/web-types-generator.ts
@@ -56,6 +56,7 @@ export function getTagList(
           description: slot.description,
         };
       }),
+      events: getWebTypeEvents(component),
       js: getJsProperties(component, options.typesSrc),
     };
   });

--- a/packages/jet-brains-integration/src/web-types-generator.ts
+++ b/packages/jet-brains-integration/src/web-types-generator.ts
@@ -25,7 +25,6 @@ import {
   createOutDir,
   logBlue,
   logRed,
-  logYellow,
   saveFile,
 } from "../../../tools/integrations";
 import { toKebabCase } from "../../../tools/utilities";

--- a/packages/jet-brains-integration/src/web-types-generator.ts
+++ b/packages/jet-brains-integration/src/web-types-generator.ts
@@ -101,12 +101,17 @@ function getWebTypeProperties(
 
 function getWebTypeEvents(component: Component): WebTypeEvent[] {
   return (
-    component.events?.map((event) => {
-      return {
-        name: event.name,
-        description: event.description,
-      };
-    }) || []
+    // The CEM analyzer will generate a custom event without a name if it is dispatched inside the
+    // custom element using a predefined constructor, but JetBrains IDEs seemingly can't do anything
+    // with unnamed Web Type events, so ignore them.
+    component.events?.filter((event) => event.name !== undefined && event.name !== null)
+      .map((event) => {
+        return {
+          name: event.name,
+          type: event.type?.text,
+          description: event.description,
+        };
+      }) || []
   );
 }
 

--- a/tools/cem-utils/src/description-templates.ts
+++ b/tools/cem-utils/src/description-templates.ts
@@ -107,7 +107,8 @@ export function getMethodsTemplate(
 
 function getEventDocs(events: schema.Event[]) {
   return events
-    ?.map((event) => `- **${event.name}** - ${event.description}`)
+    ?.filter((event) => event.name !== null && event.name !== undefined)
+  .map((event) => `- **${event.name}**${event.description ? ` - ${event.description}` : ''}`)
     .join("\n");
 }
 

--- a/tools/cem-utils/src/description-templates.ts
+++ b/tools/cem-utils/src/description-templates.ts
@@ -108,7 +108,7 @@ export function getMethodsTemplate(
 function getEventDocs(events: schema.Event[]) {
   return events
     ?.filter((event) => event.name !== null && event.name !== undefined)
-  .map((event) => `- **${event.name}**${event.description ? ` - ${event.description}` : ''}`)
+    .map((event) => `- **${event.name}**${event.description ? ` - ${event.description}` : ''}`)
     .join("\n");
 }
 


### PR DESCRIPTION
Thanks for making the generator! I was bummed out when I discovered that there isn't an official Web Types generator for pure web components yet, so I appreciate the work you've put in to translate the official web components spec to Web Types.

I took a first pass at fixing [some issues I found with the generation of JS properties and events on custom elements](https://github.com/break-stuff/cem-tools/issues/96). From my manual testing, this seems to have fixed all of the issues I was having. I couldn't get the automated tests to run on my machine, so I'm not sure if those still pass with the new changes.