### PR TITLE
fix(cem-expanded-types): pass correct options to ts.convertCompilerOptionsFromJson

### DIFF
--- a/packages/expanded-types/src/cem-plugin.ts
+++ b/packages/expanded-types/src/cem-plugin.ts
@@ -74,7 +74,7 @@ export function getTsProgram(
     configName
   );
   const { config } = ts.readConfigFile(tsConfigFile, ts.sys.readFile);
-  const compilerOptions = ts.convertCompilerOptionsFromJson(config, ".");
+  const compilerOptions = ts.convertCompilerOptionsFromJson(config.compilerOptions ?? {}, ".");
   const program = ts.createProgram(globs, compilerOptions.options);
   typeChecker = program.getTypeChecker();
   return program;


### PR DESCRIPTION
When debugging cem-expanded-types, I noticed that this line is called with incorrect argument:

https://github.com/break-stuff/cem-tools/blob/691a720dc392b3bb22a3f1661a0cfa9b61d0ca2f/packages/expanded-types/src/cem-plugin.ts#L77

The convertCompilerOptionsFromJson function is being called with `config`,  but should be called with `config.compilerOptions` instead.

At present, `ts.convertCompilerOptionsFromJson` returns these errors since it receives incorrect config object:

```json
[
  {
    "messageText": "Unknown compiler option '$schema'.",
    "category": 1,
    "code": 5023
  },
  {
    "messageText": "Unknown compiler option 'extends'.",
    "category": 1,
    "code": 5023
  },
  {
    "messageText": "Unknown compiler option 'include'.",
    "category": 1,
    "code": 5023
  },
  {
    "messageText": "Unknown compiler option 'files'.",
    "category": 1,
    "code": 5023
  },
  {
    "messageText": "Unknown compiler option 'compilerOptions'.",
    "category": 1,
    "code": 5023
  }
]
```