### PR TITLE
align default value of `propertyName` option

### DIFF
--- a/packages/expanded-types/src/cem-plugin.ts
+++ b/packages/expanded-types/src/cem-plugin.ts
@@ -329,7 +329,7 @@ function parseTypeDefinitionTypes(source: string) {
 
 function updateExpandedTypes(component: Component, context: any) {
   const typedMembers = getTypedMembers(component);
-  const propName = options.propertyName || "expandedTypes";
+  const propName = options.propertyName || "expandedType";
 
   typedMembers.forEach((member) => {
     const typeValue = getTypeValue(member, context);


### PR DESCRIPTION
Discovered a mismatch in the default value assigned to `propertyName` in the expanded-types plugin which leads to a different CEM result when passing an options object to the plugin without a `propertyName` key such as  `expandTypesPlugin({ hideLogs: true })`.

<img width="746" alt="Screenshot 2024-05-31 at 12 13 40 AM" src="https://github.com/break-stuff/cem-tools/assets/8579825/cfaa7383-df96-4b5e-a3a0-55fde7f3c7aa">

