### PR TITLE
react wrapper dynamic outdir

### DIFF
--- a/packages/react-wrappers/src/types.d.ts
+++ b/packages/react-wrappers/src/types.d.ts
@@ -3,6 +3,8 @@ import { BaseOptions } from "../../../tools/configurations";
 import type { Attribute } from "custom-elements-manifest";
 
 export interface Options extends BaseOptions {
+  /** Path to output directory */
+  outdir?: (className: string, tagName: string) => string | string;
   /** Used to get a specific path for a given component */
   modulePath?: (className: string, tagName: string) => string;
   /** Indicates if the component classes are a default export rather than a named export */

--- a/packages/react-wrappers/src/utils.ts
+++ b/packages/react-wrappers/src/utils.ts
@@ -25,19 +25,24 @@ export function getModulePath(
     );
   }
 
-  const outdirPath = typeof outdir === 'function' ? outdir(component.name, component.tagName!) : outdir;
+  const outdirPath =
+    typeof outdir === "function"
+      ? outdir(component.name, component.tagName!)
+      : outdir;
   const directories = outdirPath?.split("/");
   return path.join(directories.map((_) => "../").join(""), packageJson.module);
 }
 
 export function normalizeOutdir(outdir: any) {
-  if (typeof outdir === 'function') {
+  if (typeof outdir === "function") {
     return outdir;
   }
-  if (typeof outdir === 'string') {
+  if (typeof outdir === "string") {
     return () => outdir;
   }
-  throw new TypeError('The outdir property must be either a string or a function.');
+  throw new TypeError(
+    "The outdir property must be either a string or a function."
+  );
 }
 
 export const createEventName = (event: any) => `on${toPascalCase(event.name)}`;
@@ -117,7 +122,11 @@ export function saveReactUtils(outdir: string, ssrSafe?: boolean) {
   const reactUtils = `
 import { useEffect, useLayoutEffect } from "react";
 
-${ssrSafe ? `const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect` : ''}
+${
+  ssrSafe
+    ? `const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect`
+    : ""
+}
 
 export function useProperties(targetElement, propName, value) {
   useEffect(() => {
@@ -133,7 +142,7 @@ export function useProperties(targetElement, propName, value) {
 }
 
 export function useEventListener(targetElement, eventName, eventHandler) {
-  ${ssrSafe ? 'useIsomorphicLayoutEffect' : 'useLayoutEffect'}(() => {
+  ${ssrSafe ? "useIsomorphicLayoutEffect" : "useLayoutEffect"}(() => {
     if (eventHandler !== undefined) {
       targetElement?.current?.addEventListener(eventName, eventHandler);
     }
@@ -155,7 +164,7 @@ export function useEventListener(targetElement, eventName, eventHandler) {
 
 export function saveScopeProvider(outdir: string, ssrSafe?: boolean) {
   const scopeProvider = `
-${ssrSafe ? '"use client"' : ''}
+${ssrSafe ? '"use client"' : ""}
 import { createContext } from 'react';
 import { jsx } from "react/jsx-runtime";
 

--- a/packages/react-wrappers/src/utils.ts
+++ b/packages/react-wrappers/src/utils.ts
@@ -12,7 +12,7 @@ export function getPackageJson(): any {
 export function getModulePath(
   modulePath: ((className: string, tagName: string) => string) | undefined,
   component: Component,
-  outdir: string,
+  outdir: (className: string, tagName: string) => string | string,
   packageJson: any
 ) {
   if (modulePath instanceof Function) {
@@ -25,8 +25,20 @@ export function getModulePath(
     );
   }
 
-  const directories = outdir?.split("/");
+  const outdirPath = typeof outdir === 'function' ? outdir(component.name, component.tagName!) : outdir;
+  const directories = outdirPath?.split("/");
   return path.join(directories.map((_) => "../").join(""), packageJson.module);
+}
+
+export function normalizeOutdir(outdir: any) {
+  console.log("Normalizing outdir:", outdir, "Type:", typeof outdir);
+  if (typeof outdir === 'function') {
+    return outdir;
+  }
+  if (typeof outdir === 'string') {
+    return () => outdir;
+  }
+  throw new TypeError('The outdir property must be either a string or a function.');
 }
 
 export const createEventName = (event: any) => `on${toPascalCase(event.name)}`;

--- a/packages/react-wrappers/src/utils.ts
+++ b/packages/react-wrappers/src/utils.ts
@@ -31,7 +31,6 @@ export function getModulePath(
 }
 
 export function normalizeOutdir(outdir: any) {
-  console.log("Normalizing outdir:", outdir, "Type:", typeof outdir);
   if (typeof outdir === 'function') {
     return outdir;
   }

--- a/packages/react-wrappers/src/wrapper-generator.ts
+++ b/packages/react-wrappers/src/wrapper-generator.ts
@@ -155,14 +155,14 @@ function generateReactWrapper(
   relativePathToCommonRoot: string,
   properties?: ClassField[]
 ) {
-  // Ensure outdir is always treated as a function
+  /**  Ensure outdir is always treated as a function */
   const outdir = config.outdir!;
   const componentOutDir =
     typeof outdir === "function"
       ? outdir(component.name, component.tagName!)
       : outdir;
 
-  // Handle empty relative path case
+  /** Handle empty relative path case */
   const adjustedRelativePathToCommonRoot =
     relativePathToCommonRoot === "" ? "." : relativePathToCommonRoot;
 
@@ -718,7 +718,6 @@ function getManifestContentTemplate(
     })
     .join("\n");
 
-  // Add ScopeProvider export directly
   if (config.scopedTags) {
     exports += `\nexport * from './ScopeProvider.js';`;
   }

--- a/packages/react-wrappers/src/wrapper-generator.ts
+++ b/packages/react-wrappers/src/wrapper-generator.ts
@@ -15,7 +15,12 @@ import {
   saveReactUtils,
   saveScopeProvider,
 } from "./utils.js";
-import { createOutDir, logBlue, logYellow, saveFile } from "../../../tools/integrations/index.js";
+import {
+  createOutDir,
+  logBlue,
+  logYellow,
+  saveFile,
+} from "../../../tools/integrations/index.js";
 import {
   CEM,
   Component,
@@ -36,11 +41,14 @@ import { BaseOptions } from "../../../tools/configurations/index.js";
 
 const packageJson = getPackageJson();
 let config: Options = {
-  outdir: (className: string, tagName: string) => `./react`
+  outdir: (className: string, tagName: string) => `./react`,
 };
 let globalEvents: GlobalEvent[] = [];
 
-export function generateReactWrappers(customElementsManifest: CEM, options: Options) {
+export function generateReactWrappers(
+  customElementsManifest: CEM,
+  options: Options
+) {
   if (options.skip) {
     logYellow("[react-wrappers] - Skipped", options.hideLogs);
     return;
@@ -51,22 +59,33 @@ export function generateReactWrappers(customElementsManifest: CEM, options: Opti
 
   const components = getComponents(customElementsManifest, config.exclude);
 
-  const uniqueOutDirs = new Set<string>(components.map(c => {
-    const outdir = config.outdir;
-    return typeof outdir === 'function' ? outdir(c.name, c.tagName!) : outdir;
-  }).filter((dir): dir is string => typeof dir === 'string'));
+  const uniqueOutDirs = new Set<string>(
+    components
+      .map((c) => {
+        const outdir = config.outdir;
+        return typeof outdir === "function"
+          ? outdir(c.name, c.tagName!)
+          : outdir;
+      })
+      .filter((dir): dir is string => typeof dir === "string")
+  );
 
   const commonRoot = getCommonRoot(Array.from(uniqueOutDirs));
 
   if (!commonRoot) {
-    throw new Error("Common root directory could not be determined. Ensure all component directories have a common path.");
+    throw new Error(
+      "Common root directory could not be determined. Ensure all component directories have a common path."
+    );
   }
 
   createOutDir(commonRoot);
   saveScopeProvider(commonRoot, config.ssrSafe);
 
   components.forEach((component) => {
-    const componentOutDir = typeof config.outdir === 'function' ? config.outdir(component.name, component.tagName!) : config.outdir;
+    const componentOutDir =
+      typeof config.outdir === "function"
+        ? config.outdir(component.name, component.tagName!)
+        : config.outdir;
     if (!componentOutDir) return;
 
     createOutDir(componentOutDir);
@@ -82,7 +101,9 @@ export function generateReactWrappers(customElementsManifest: CEM, options: Opti
       packageJson
     );
 
-    const relativePathToCommonRoot = path.relative(componentOutDir, commonRoot).replace(/\\/g, '/');
+    const relativePathToCommonRoot = path
+      .relative(componentOutDir, commonRoot)
+      .replace(/\\/g, "/");
 
     generateReactWrapper(
       component,
@@ -106,7 +127,10 @@ export function generateReactWrappers(customElementsManifest: CEM, options: Opti
 
   generateManifests(components, config.outdir!, commonRoot);
 
-  logBlue(`[react-wrappers] - Generated wrappers in "${config.outdir}".`, config.hideLogs);
+  logBlue(
+    `[react-wrappers] - Generated wrappers in "${config.outdir}".`,
+    config.hideLogs
+  );
 }
 
 function updateConfig(options: Options) {
@@ -120,7 +144,6 @@ function updateConfig(options: Options) {
   };
 
   globalEvents = options.globalEvents || [];
-
 }
 
 function generateReactWrapper(
@@ -134,10 +157,14 @@ function generateReactWrapper(
 ) {
   // Ensure outdir is always treated as a function
   const outdir = config.outdir!;
-  const componentOutDir = typeof outdir === 'function' ? outdir(component.name, component.tagName!) : outdir;
+  const componentOutDir =
+    typeof outdir === "function"
+      ? outdir(component.name, component.tagName!)
+      : outdir;
 
   // Handle empty relative path case
-  const adjustedRelativePathToCommonRoot = relativePathToCommonRoot === "" ? "." : relativePathToCommonRoot;
+  const adjustedRelativePathToCommonRoot =
+    relativePathToCommonRoot === "" ? "." : relativePathToCommonRoot;
 
   const result = getReactComponentTemplate(
     component,
@@ -169,21 +196,35 @@ function generateTypeDefinition(
     properties
   );
 
-  const componentOutDir = typeof config.outdir === 'function' ? config.outdir(component.name, component.tagName!) : config.outdir;
+  const componentOutDir =
+    typeof config.outdir === "function"
+      ? config.outdir(component.name, component.tagName!)
+      : config.outdir;
   saveFile(componentOutDir!, `${component.name}.d.ts`, result, "typescript");
 }
 
-function generateManifests(components: Component[], outdir: (className: string, tagName: string) => string | string, commonRoot: string) {
+function generateManifests(
+  components: Component[],
+  outdir: (className: string, tagName: string) => string | string,
+  commonRoot: string
+) {
   const uniqueOutDirs = new Set<string>();
 
-  components.forEach(component => {
-    const componentOutDir = typeof outdir === 'function' ? outdir(component.name, component.tagName!) : outdir;
+  components.forEach((component) => {
+    const componentOutDir =
+      typeof outdir === "function"
+        ? outdir(component.name, component.tagName!)
+        : outdir;
     uniqueOutDirs.add(componentOutDir);
   });
 
   createOutDir(commonRoot);
 
-  const manifestContent = getManifestContentTemplate(components, outdir, commonRoot);
+  const manifestContent = getManifestContentTemplate(
+    components,
+    outdir,
+    commonRoot
+  );
 
   saveFile(commonRoot, "index.js", manifestContent, "typescript");
   saveFile(commonRoot, "index.d.ts", manifestContent, "typescript");
@@ -192,14 +233,14 @@ function generateManifests(components: Component[], outdir: (className: string, 
 function getCommonRoot(dirs: string[]): string {
   if (!dirs.length) return "./react";
 
-  const normalizedDirs = dirs.map(dir => path.normalize(dir));
-  const splitDirs = normalizedDirs.map(dir => dir.split(path.sep));
-  const minLength = Math.min(...splitDirs.map(split => split.length));
+  const normalizedDirs = dirs.map((dir) => path.normalize(dir));
+  const splitDirs = normalizedDirs.map((dir) => dir.split(path.sep));
+  const minLength = Math.min(...splitDirs.map((split) => split.length));
   const commonRootSegments: string[] = [];
 
   for (let i = 0; i < minLength; i++) {
     const segment = splitDirs[0][i];
-    if (splitDirs.every(split => split[i] === segment)) {
+    if (splitDirs.every((split) => split[i] === segment)) {
       commonRootSegments.push(segment);
       logBlue(`Common segment '${segment}' found at index ${i}`);
     } else {
@@ -385,23 +426,35 @@ function getReactComponentTemplate(
 
   return `
     ${config.ssrSafe ? '"use client"' : ""}
-    import React, { forwardRef, useImperativeHandle ${config.scopedTags ? ", useContext" : ""} ${useEffect ? ", useRef, useEffect" : ""} } from "react";
+    import React, { forwardRef, useImperativeHandle ${
+      config.scopedTags ? ", useContext" : ""
+    } ${useEffect ? ", useRef, useEffect" : ""} } from "react";
     ${!config.ssrSafe ? `import '${modulePath}';` : ""}
-    ${config.scopedTags ? `import { ScopeContext } from "${relativePathToCommonRoot}/ScopeProvider.js";` : ""}
-    ${has(eventTemplates) || has(propTemplates)
-      ? `import { 
+    ${
+      config.scopedTags
+        ? `import { ScopeContext } from "${relativePathToCommonRoot}/ScopeProvider.js";`
+        : ""
+    }
+    ${
+      has(eventTemplates) || has(propTemplates)
+        ? `import { 
           ${has(eventTemplates) ? "useEventListener," : ""} 
           ${has(propTemplates) ? "useProperties" : ""}
         } from '${relativePathToCommonRoot}/react-utils.js';`
-      : ""
+        : ""
     }
 
     export const ${component.name} = forwardRef((props, forwardedRef) => {
       ${useEffect ? `const ref = useRef(null);` : ""}
-      ${has(unusedProps) ? `const { ${unusedProps.join(", ")}, ...filteredProps } = props;` : ''}
+      ${
+        has(unusedProps)
+          ? `const { ${unusedProps.join(", ")}, ...filteredProps } = props;`
+          : ""
+      }
       ${config.scopedTags ? "const scope = useContext(ScopeContext);" : ""}
 
-      ${config.ssrSafe
+      ${
+        config.ssrSafe
           ? `
       /** Waits for the client before loading the custom element */
       useEffect(() => {
@@ -414,10 +467,18 @@ function getReactComponentTemplate(
       ${has(eventTemplates) ? "/** Event listeners - run once */" : ""}
       ${eventTemplates?.join("") || ""}
 
-      ${has(propTemplates) ? "/** Properties - run whenever a property has changed */" : ""}
+      ${
+        has(propTemplates)
+          ? "/** Properties - run whenever a property has changed */"
+          : ""
+      }
       ${propTemplates?.join("") || ""}
 
-      ${has(methods) ? "/** Methods - uses `useImperativeHandle` hook to pass ref to component */" : ""}
+      ${
+        has(methods)
+          ? "/** Methods - uses `useImperativeHandle` hook to pass ref to component */"
+          : ""
+      }
       useImperativeHandle(forwardedRef, () => ({
         ${getPublicMethodsForRef(methods)}
       }));
@@ -436,10 +497,16 @@ function getReactComponentTemplate(
     });
   `;
 }
+
 function convertOptionsToBaseOptions(options: Options): BaseOptions {
   return {
     ...options,
-    outdir: typeof options.outdir === 'string' ? options.outdir : options.outdir ? options.outdir('', '') : undefined
+    outdir:
+      typeof options.outdir === "string"
+        ? options.outdir
+        : options.outdir
+        ? options.outdir("", "")
+        : undefined,
   };
 }
 
@@ -634,13 +701,19 @@ function getGlobalEventPropsTemplate(events: GlobalEvent[] | undefined) {
   );
 }
 
-function getManifestContentTemplate(components: Component[], outdir: (className: string, tagName: string) => string | string, commonRoot: string) {
-  const resolveOutDir = typeof outdir === 'function' ? outdir : () => outdir;
+function getManifestContentTemplate(
+  components: Component[],
+  outdir: (className: string, tagName: string) => string | string,
+  commonRoot: string
+) {
+  const resolveOutDir = typeof outdir === "function" ? outdir : () => outdir;
 
   let exports = components
-    .map(component => {
+    .map((component) => {
       const componentOutDir = resolveOutDir(component.name, component.tagName!);
-      const relativePath = path.relative(commonRoot, componentOutDir).replace(/\\/g, '/');
+      const relativePath = path
+        .relative(commonRoot, componentOutDir)
+        .replace(/\\/g, "/");
       return `export * from './${relativePath}/${component.name}.js';`;
     })
     .join("\n");
@@ -652,7 +725,6 @@ function getManifestContentTemplate(components: Component[], outdir: (className:
 
   return exports;
 }
-
 
 function getEventType(eventType?: string, eventCustom?: boolean) {
   if (eventCustom) {


### PR DESCRIPTION
## Summary

This PR introduces the ability to set dynamic output directories for the React wrappers generated by the `custom-element-react-wrappers` plugin. The implementation ensures backward compatibility by allowing the `outDir` property to accept both a static string and a dynamic function.

## Changes

### Core Changes
1. **Dynamic `outDir` Handling**:
   - Modified the `outDir` property in `Options` to accept either a static string or a function.
   - Updated the `generateReactWrappers` function to handle dynamic output directories.

2. **Common Root Directory Calculation**:
   - Added logic to determine the common root directory when dynamic paths are provided.
   - Ensured that the barrel file and utility files (`ScopeProvider`, `react-utils`) are output to this common root directory.

### Detailed Changes
1. **Updated Interfaces**:
   - Updated the `Options` interface to support dynamic `outDir`.
   - Ensured backward compatibility with static string `outDir`.

2. **Normalization of `outDir`**:
   - Added a `normalizeOutdir` function to handle both string and function types for `outDir`.

3. **Barrel File Generation**:
   - Updated the logic in `getManifestContentTemplate` to correctly handle the export paths for `ScopeProvider` and other components based on the common root directory.
   - Ensured that `ScopeProvider` is always exported from the common root level.

4. **Utility File Generation**:
   - Adjusted paths for `react-utils` and `ScopeProvider` to ensure correct import paths based on the calculated common root directory.
   
  ### Examples
  
  **Example 1: dynamic outDir**
  
  config:
  
  ```ts
      customElementReactWrapperPlugin({
      outdir: (className, tagName) => `./dist/react/${tagName}`,
      modulePath: (className, tagName) => `../../../${tagName}/${tagName}.js`,
      reactProps: true,
      scopedTags: true,
      ssrSafe: true
    }),
  ```
  
 directory structure:
  
![image](https://github.com/break-stuff/cem-tools/assets/11062709/a97d12e0-fc6f-4f65-8f42-2140da9cdb26)

barrel:

![image](https://github.com/break-stuff/cem-tools/assets/11062709/73ea7a65-e4bd-4910-8a68-cc9463a8fbf2)

dynamic imports:

![image](https://github.com/break-stuff/cem-tools/assets/11062709/2dd3d24c-2888-4cbe-897a-bc4256a90caf)

**Example 2: complex dynamic outDir**

config:

```ts
    customElementReactWrapperPlugin({
      outdir: (className, tagName) => `./dist/react/components/${tagName}/component`,
      modulePath: (className, tagName) => `../../../${tagName}/${tagName}.js`,
      reactProps: true,
      scopedTags: true,
      ssrSafe: true
    }),
```

directory structure:

![image](https://github.com/break-stuff/cem-tools/assets/11062709/363252bb-9557-4a93-a643-9c5f85d1fa68)

barrel:
![image](https://github.com/break-stuff/cem-tools/assets/11062709/8c697f3c-5616-43f7-9d14-0b5cf8c20913)

dynamic imports:
![image](https://github.com/break-stuff/cem-tools/assets/11062709/cf104115-40c2-44a8-8cfd-b283d2b1f138)

**Example 3: `outDir` as `string`**

config:

```ts
    customElementReactWrapperPlugin({
      outdir: "./dist/react",
      modulePath: (className, tagName) => `../${tagName}/${tagName}.js`,
      reactProps: true,
      scopedTags: true,
      ssrSafe: true
    }),
```

directory structure:
![image](https://github.com/break-stuff/cem-tools/assets/11062709/7110d476-0dad-4ef6-a1dc-2d47488a4770)

barrel:
![image](https://github.com/break-stuff/cem-tools/assets/11062709/94628bca-5c50-4dca-9795-ee8d42fc8007)

**Example 4: default**

config:
```ts
    customElementReactWrapperPlugin({
      modulePath: (className, tagName) => `../${tagName}/${tagName}.js`,
      reactProps: true,
      scopedTags: true,
      ssrSafe: true
    }),
```

directory structure:
![image](https://github.com/break-stuff/cem-tools/assets/11062709/50108695-4552-41e5-a76d-32869c3faff0)

barrel:
![image](https://github.com/break-stuff/cem-tools/assets/11062709/74a0f89d-3481-41d0-9793-f0faead11acc)


