### PR TITLE
use intersection versus union for interface generation

### DIFF
--- a/packages/jsx-integration/src/type-generator.ts
+++ b/packages/jsx-integration/src/type-generator.ts
@@ -210,7 +210,7 @@ ${components
     */
     "${options.prefix}${component.tagName}${options.suffix}": Partial<${
       component.name
-    }Props | BaseProps | BaseEvents>;`;
+    }Props & BaseProps & BaseEvents>;`;
   })
   .join("\n")}
   }


### PR DESCRIPTION
When a union type is used, it prevents combining properties from the different interfaces, so you can't have a custom attribute along with `className` on the same element despite the combination being valid. With an intersection type, you can combine partials of both without it throwing a compiler error.