### PR TITLE
fix: types declaration resolution with node16/next

### DIFF
--- a/packages/cem-inheritance/index.d.ts
+++ b/packages/cem-inheritance/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/index";
+export * from "./dist/index.js";

--- a/packages/custom-jsdoc-tags/index.d.ts
+++ b/packages/custom-jsdoc-tags/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/index";
+export * from "./dist/index.js";

--- a/packages/deprecator/index.d.ts
+++ b/packages/deprecator/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/index";
+export * from "./dist/index.js";

--- a/packages/expanded-types/index.d.ts
+++ b/packages/expanded-types/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/index";
+export * from "./dist/index.js";

--- a/packages/jet-brains-integration/index.d.ts
+++ b/packages/jet-brains-integration/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/index";
+export * from "./dist/index.js";

--- a/packages/jsx-integration/index.d.ts
+++ b/packages/jsx-integration/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/index";
+export * from "./dist/index.js";

--- a/packages/react-wrappers/index.d.ts
+++ b/packages/react-wrappers/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/index";
+export * from "./dist/index.js";

--- a/packages/solidjs-integration/index.d.ts
+++ b/packages/solidjs-integration/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/index";
+export * from "./dist/index.js";

--- a/packages/svelte-integration/index.d.ts
+++ b/packages/svelte-integration/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/index";
+export * from "./dist/index.js";

--- a/packages/vs-code-integration/index.d.ts
+++ b/packages/vs-code-integration/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/index";
+export * from "./dist/index.js";

--- a/packages/vuejs-integration/index.d.ts
+++ b/packages/vuejs-integration/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/index";
+export * from "./dist/index.js";


### PR DESCRIPTION
With all the packages being ESM (`"type": "module"`), [`node16`/`nodenext`](https://www.typescriptlang.org/docs/handbook/modules/theory.html#module-resolution) module resolution requires file extensions for imports to work and that mechanism is applied similarly for type declarations too. The existing export:
```ts
export * from "./dist/index";
```
only works for old `node10`, but the new ones can't follow the path and thus no exported types are visible and so we get IDE & build errors like this one:
```shell
src/test.mts:5:10 - error TS2305: Module '"custom-element-jet-brains-integration"' has no exported member 'getWebTypesData'.

5 import { getWebTypesData } from 'custom-element-jet-brains-integration';
```

  | "custom-element-jet-brains-integration"
-- | --
node10 | ✅
node16 (from CJS) | ⚠️ ESM (dynamic import only) <br> 🥴 Internal resolution error
node16 (from ESM) | 🥴 Internal resolution error
bundler | ✅

https://arethetypeswrong.github.io/?p=custom-element-jet-brains-integration%401.6.2

With the `.js` extension locally:
  | "custom-element-jet-brains-integration"
-- | --
node10 | 🟢
node16 (from CJS) | ⚠️ ESM (dynamic import only)
node16 (from ESM) | 🟢 (ESM)
bundler | 🟢

PS: Noticed there's a `cjs` file output compiled, but note that CommonJS `require` still only works on direct subpath to `/dist/index.cjs` for similar reasons - the main `index.js` is still ESM. Might want to consider separate export entry points ([example](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package.json-exports-imports-and-self-referencing)) for that to work out-of-the-box.