### PR TITLE
add exports for mjs and cjs

### DIFF
--- a/demo/lit-app/solid-js.d.ts
+++ b/demo/lit-app/solid-js.d.ts
@@ -184,7 +184,7 @@ export type CustomElements = {
    * ### **CSS Parts:**
    *  - **radio-label** - Applies custom styles the radio group label
    */
-  "radio-group": Partial<RadioGroupProps | BaseProps | BaseEvents>;
+  "radio-group": Partial<RadioGroupProps & BaseProps & BaseEvents>;
 
   /**
    * Radio buttons allow users to select a single option from a group. Here is its [documentation](https://my-site.com/documentation).
@@ -199,7 +199,7 @@ export type CustomElements = {
    * ### **Slots:**
    *  - _default_ - add text here to label your radio button
    */
-  "radio-button": Partial<RadioButtonProps | BaseProps | BaseEvents>;
+  "radio-button": Partial<RadioButtonProps & BaseProps & BaseEvents>;
 
   /**
    * @deprecated An example of a deprecated element
@@ -209,7 +209,7 @@ export type CustomElements = {
    *
    */
   "deprecated-element": Partial<
-    DeprecatedElementProps | BaseProps | BaseEvents
+    DeprecatedElementProps & BaseProps & BaseEvents
   >;
 
   /**
@@ -218,5 +218,5 @@ export type CustomElements = {
    * ---
    *
    */
-  "my-button": Partial<MyButtonProps | BaseProps | BaseEvents>;
+  "my-button": Partial<MyButtonProps & BaseProps & BaseEvents>;
 };

--- a/packages/cem-inheritance/CHANGELOG.md
+++ b/packages/cem-inheritance/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.1.1
 
 - Prevent overriding CEM when Analyzer is used

--- a/packages/cem-inheritance/package.json
+++ b/packages/cem-inheritance/package.json
@@ -1,11 +1,18 @@
 {
   "name": "custom-elements-manifest-inheritance",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A tool for mapping inherited content (including class members, attributes, CSS parts, CSS variables, slots, and events) from parent classes in the Custom Elements Manifest",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/custom-jsdoc-tags/CHANGELOG.md
+++ b/packages/custom-jsdoc-tags/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.1.2
 
 - Removed duplicate logs

--- a/packages/custom-jsdoc-tags/package.json
+++ b/packages/custom-jsdoc-tags/package.json
@@ -1,11 +1,18 @@
 {
   "name": "cem-plugin-custom-jsdoc-tags",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Translates custom JSDoc tags to the Custom Elements Manifest",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/deprecator/CHANGELOG.md
+++ b/packages/deprecator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.1.2
 
 - Fixed imported function name in `README.md`

--- a/packages/deprecator/package.json
+++ b/packages/deprecator/package.json
@@ -1,11 +1,18 @@
 {
   "name": "custom-elements-manifest-deprecator",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A tool for marking Custom Elements Manifest data as 'deprecated'",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.1.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.0.0
 
 - Initial release

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,11 +1,18 @@
 {
   "name": "eslint-plugin-custom-element",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "This plugin creates rules specific for validating custom element implementation in HTML",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/eslint-rules/CHANGELOG.md
+++ b/packages/eslint-rules/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.1.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.0.1
 
 - Fixed async file output

--- a/packages/eslint-rules/package.json
+++ b/packages/eslint-rules/package.json
@@ -1,11 +1,18 @@
 {
   "name": "custom-element-eslint-rule-generator",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A tool for generating eslint rules for your custom elements.",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/expanded-types/CHANGELOG.md
+++ b/packages/expanded-types/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.3.2
 
 - Removed duplicate logs

--- a/packages/expanded-types/package.json
+++ b/packages/expanded-types/package.json
@@ -1,11 +1,18 @@
 {
   "name": "cem-plugin-expanded-types",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "A CEM Analyzer plugin to add expanded TypeScript types to the Custom Elements Manifest",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/jet-brains-integration/CHANGELOG.md
+++ b/packages/jet-brains-integration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.7.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.6.2
 
 - Fixed async file output

--- a/packages/jet-brains-integration/package.json
+++ b/packages/jet-brains-integration/package.json
@@ -1,11 +1,18 @@
 {
   "name": "custom-element-jet-brains-integration",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Tools for integrating web components/custom elements into JetBrains IDEs",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/jsx-integration/CHANGELOG.md
+++ b/packages/jsx-integration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.6.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.5.4
 
 - Updated messaging in `README.md` for react wrappers

--- a/packages/jsx-integration/package.json
+++ b/packages/jsx-integration/package.json
@@ -1,11 +1,18 @@
 {
   "name": "custom-element-jsx-integration",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "description": "Tools for integrating custom elements into JSX projects",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/lazy-loader/CHANGELOG.md
+++ b/packages/lazy-loader/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.4.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.3.1
 
 - Fixed async file output

--- a/packages/lazy-loader/package.json
+++ b/packages/lazy-loader/package.json
@@ -1,11 +1,18 @@
 {
   "name": "custom-element-lazy-loader",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A tool for generating an entry point for lazy-loading custom elements/web components.",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/react-wrappers/CHANGELOG.md
+++ b/packages/react-wrappers/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.7.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.6.8
 
 - Updated to import `React` in types

--- a/packages/react-wrappers/package.json
+++ b/packages/react-wrappers/package.json
@@ -1,11 +1,18 @@
 {
   "name": "custom-element-react-wrappers",
-  "version": "1.6.8",
+  "version": "1.7.0",
   "description": "A tool for generating react-compatible wrappers for custom elements",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/solidjs-integration/CHANGELOG.md
+++ b/packages/solidjs-integration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.9.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.8.2
 
 - Updated to use intersection types rather than union types

--- a/packages/solidjs-integration/package.json
+++ b/packages/solidjs-integration/package.json
@@ -1,11 +1,18 @@
 {
   "name": "custom-element-solidjs-integration",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "Tools for integrating custom elements into SolidJS",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/svelte-integration/CHANGELOG.md
+++ b/packages/svelte-integration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.2.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.1.2
 
 - Updated to use intersection types rather than union types

--- a/packages/svelte-integration/package.json
+++ b/packages/svelte-integration/package.json
@@ -1,11 +1,18 @@
 {
   "name": "custom-element-svelte-integration",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Tools for integrating custom elements into a Svelte project",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/vs-code-integration/CHANGELOG.md
+++ b/packages/vs-code-integration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.5.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.4.1
 
 - Fixed async file output

--- a/packages/vs-code-integration/package.json
+++ b/packages/vs-code-integration/package.json
@@ -1,11 +1,18 @@
 {
   "name": "custom-element-vs-code-integration",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Tools for integrating web components/custom elements into VS Code",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",

--- a/packages/vuejs-integration/CHANGELOG.md
+++ b/packages/vuejs-integration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.4.0
+
+- Fixed exports for projects that have the `type` of "module"
+- Added `cjs` exports
+
 ## 1.3.3
 
 - Updated to use intersection types rather than union types

--- a/packages/vuejs-integration/package.json
+++ b/packages/vuejs-integration/package.json
@@ -1,11 +1,18 @@
 {
   "name": "custom-element-vuejs-integration",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Types for integrating custom elements into Vue.js projects",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",


### PR DESCRIPTION
- Fixed exports for projects that have the `type` of "module"
- Added `cjs` exports