### PR TITLE
fix: export Options type

### DIFF
--- a/packages/jsx-integration/src/index.ts
+++ b/packages/jsx-integration/src/index.ts
@@ -1,2 +1,3 @@
-export { generateJsxTypes } from "./type-generator";
 export { customElementJsxPlugin } from "./cem-analyzer-plugin";
+export { generateJsxTypes } from "./type-generator";
+export type { Options } from "./types";

--- a/packages/react-wrappers/src/index.ts
+++ b/packages/react-wrappers/src/index.ts
@@ -1,2 +1,3 @@
-export { generateReactWrappers } from "./wrapper-generator";
 export { customElementReactWrapperPlugin } from "./cem-analyzer-plugin";
+export type { Options } from "./types";
+export { generateReactWrappers } from "./wrapper-generator";


### PR DESCRIPTION
add type export of Options to the packages `jsx-integration` and `react-wrappers`.