### PR TITLE
Feat/cem module path as module path

### DIFF
--- a/packages/react-wrappers/src/types.d.ts
+++ b/packages/react-wrappers/src/types.d.ts
@@ -4,7 +4,11 @@ import type { Attribute } from "custom-elements-manifest";
 
 export interface Options extends BaseOptions {
   /** Used to get a specific path for a given component */
-  modulePath?: (className: string, tagName: string) => string;
+  modulePath?: (
+    className: string,
+    tagName: string,
+    modulePath: string,
+  ) => string;
   /** Indicates if the component classes are a default export rather than a named export */
   defaultExport?: boolean;
   /** Used to provide alternative property name to prevent name collisions with React */

--- a/packages/react-wrappers/src/utils.ts
+++ b/packages/react-wrappers/src/utils.ts
@@ -1,8 +1,9 @@
-import path from "path";
 import fs from "fs";
+import path from "path";
+import { Component } from "../../../tools/cem-utils/index.js";
 import { saveFile } from "../../../tools/integrations/index.js";
 import { toPascalCase } from "../../../tools/utilities/index.js";
-import { Component } from "../../../tools/cem-utils/index.js";
+import type { Options } from "./types.js";
 
 export function getPackageJson(): any {
   const packageJsonPath = path.join(process.cwd(), "package.json");
@@ -10,7 +11,7 @@ export function getPackageJson(): any {
 }
 
 export function getModulePath(
-  modulePath: ((className: string, tagName: string) => string) | undefined,
+  modulePath: Options["modulePath"] | undefined,
   component: Component,
   outdir: string,
   packageJson: any,

--- a/packages/react-wrappers/src/utils.ts
+++ b/packages/react-wrappers/src/utils.ts
@@ -16,7 +16,11 @@ export function getModulePath(
   packageJson: any,
 ) {
   if (modulePath instanceof Function) {
-    return modulePath(component.name, component.tagName!);
+    return modulePath(
+      component.name,
+      component.tagName!,
+      component.modulePath!,
+    );
   }
 
   if (!packageJson.module) {

--- a/tools/cem-utils/src/cem-utilities.ts
+++ b/tools/cem-utils/src/cem-utilities.ts
@@ -53,15 +53,17 @@ export function getComponents(
   exclude?: string[],
 ): Component[] {
   return (
-    customElementsManifest.modules?.map(
-      (mod) =>
+    customElementsManifest.modules?.map((mod) => {
+      const comp =
         mod?.declarations?.filter(
           (dec) =>
-            !exclude?.includes(dec.name) &&
-            ((dec as Component).customElement || (dec as Component).tagName),
-        ) || [],
-    ) || []
-  ).flat() as Component[];
+            !exclude?.includes(dec.name) && (dec.customElement || dec.tagName),
+        ) || [];
+
+      if (comp.length <= 0) return [];
+      return [Object.assign({ modulePath: mod.path }, ...comp)];
+    }) || []
+  ).flat();
 }
 /**
  * Gets a list of public properties from a CEM component

--- a/tools/cem-utils/src/types.d.ts
+++ b/tools/cem-utils/src/types.d.ts
@@ -11,6 +11,7 @@ export interface CssProperty extends schema.CssCustomProperty {
 }
 
 export interface Component extends schema.CustomElementDeclaration {
+  modulePath?: string;
   cssProperties?: CssProperty[];
   members?: Array<schema.ClassMember>;
   superclass?: {


### PR DESCRIPTION
With the `customElementReactWrapperPlugin` the configuration option provided by providing a custom modulePath with the given parameters is not sufficient for web-components and their generated wrappers. Namely, if components are grouped in a directory, like `myCustomTab` and `myCustomTabs` it can create the impossible challenge to use `className` and `tagName` to resolve the path to the correct component.

consider the following structure for the custom-elements:

```javascript
modulePath: (className, tagName) => `./${tagName}/${className}.js` 
``` 

```bash
|- src
|-- tabs
|--- myCustomTab.js
|--- myCustomTabs.js
```

```js
/**
 * @tag my-custom-tab
 */
export class MyCustomTab extends HTMLElement { /* ... */ }
```

```javascript
/**
 * @tag my-custom-tabs
 */
export class MyCustomTabs extends HTMLElement { /* ... */ }
```

the output will be two components with the path
```bash
./my-custom-tab/MyCustomTab.js
./my-custom-tabs/MyCustomTabs.js
```

Even if you would configure the `modulePath` differently like `${tagName.split('-').reverse()[0]}` you wouldn't get the desired outcome.

```bash
./tab/MyCustomTab.js
./tabs/MyCustomTabs.js
```

CEM provides a path which is better suited to do some custom modulePath resolution:

```json
{
      "kind": "javascript-module",
      "path": "src/tabs/MyCustomTab.js",
      "declarations": [
        {
          "kind": "class",
          "description": "",
          "name": "MyCustomTab",
          "...": "..."
         }
      ]
}
```

This PR adds this functionality.