### PR TITLE
feat(jet-brains-integration): add source module and symbol in web-types

### DIFF
--- a/packages/jet-brains-integration/README.md
+++ b/packages/jet-brains-integration/README.md
@@ -118,6 +118,8 @@ export interface Options {
   hideLogs?: boolean;
   /** Prevents plugin from executing */
   skip?: boolean;
+  /** Used to amend the modules paths to actual source (when outdir is a subdirectory for instance) */
+  modulePathTemplate?: (name: string, modulePath: string) => string;
 }
 ```
 

--- a/packages/jet-brains-integration/src/__tests__/web-types-generator.ts
+++ b/packages/jet-brains-integration/src/__tests__/web-types-generator.ts
@@ -1,6 +1,10 @@
 import { expect, describe, test } from "vitest";
 import { customElementsManifest } from "./test-data";
-import { getOptions, getTagList } from "../web-types-generator";
+import {
+  getOptions,
+  getTagList,
+  getComponentsExportsMap,
+} from "../web-types-generator";
 import { getComponents } from "../../../../tools/cem-utils";
 
 describe("web-types-generator", () => {
@@ -28,9 +32,10 @@ describe("web-types-generator", () => {
           slots: slotLabel,
         },
       });
+      const symbols = getComponentsExportsMap(customElementsManifest, options);
 
       // Act
-      const tagList = getTagList(components, options);
+      const tagList = getTagList(components, symbols, options);
 
       // Assert
       expect(options.labels?.slots).toBe("Slug");
@@ -43,9 +48,10 @@ describe("web-types-generator", () => {
       const options = getOptions({
         hideSlotDocs: false,
       });
+      const symbols = getComponentsExportsMap(customElementsManifest, options);
 
       // Act
-      const tagList = getTagList(components, options);
+      const tagList = getTagList(components, symbols, options);
 
       // Assert
       expect(JSON.stringify(tagList).includes("**Slots:**")).toBe(false);
@@ -56,9 +62,10 @@ describe("web-types-generator", () => {
       const options = getOptions({
         hideEventDocs: false,
       });
+      const symbols = getComponentsExportsMap(customElementsManifest, options);
 
       // Act
-      const tagList = getTagList(components, options);
+      const tagList = getTagList(components, symbols, options);
 
       // Assert
       expect(JSON.stringify(tagList).includes("**Events:**")).toBe(false);
@@ -70,8 +77,10 @@ describe("web-types-generator", () => {
         hideCssPropertiesDocs: false,
       });
 
+      const symbols = getComponentsExportsMap(customElementsManifest, options);
+
       // Act
-      const tagList = getTagList(components, options);
+      const tagList = getTagList(components, symbols, options);
 
       // Assert
       expect(JSON.stringify(tagList).includes("**CSS Properties:**")).toBe(
@@ -84,9 +93,10 @@ describe("web-types-generator", () => {
       const options = getOptions({
         hideCssPartsDocs: false,
       });
+      const symbols = getComponentsExportsMap(customElementsManifest, options);
 
       // Act
-      const tagList = getTagList(components, options);
+      const tagList = getTagList(components, symbols, options);
 
       // Assert
       expect(JSON.stringify(tagList).includes("**CSS Parts:**")).toBe(false);

--- a/packages/jet-brains-integration/src/types.d.ts
+++ b/packages/jet-brains-integration/src/types.d.ts
@@ -22,6 +22,8 @@ export interface Options extends BaseOptions {
   referenceTemplate?: (name: string, tag?: string) => Reference;
   /** Adds an icon link to the webtypes.json  **/
   defaultIcon?: string;
+  /** Used to amend the modules paths to actual source (when outdir is a subdirectory for instance) */
+  modulePathTemplate?: (name: string, modulePath: string) => string;
 }
 
 export interface Params {
@@ -31,6 +33,7 @@ export interface Params {
 export interface WebTypeElement {
   name: string;
   description: string;
+  source?: WebTypeSourceSymbol;
   ["doc-url"]?: string;
   attributes: WebTypeAttribute[];
   js?: JsProperties;
@@ -82,4 +85,9 @@ export interface WebTypeCssProperty {
 export interface Reference {
   name: string;
   url: string;
+}
+
+export interface WebTypeSourceSymbol {
+  module?: string;
+  symbol: string;
 }


### PR DESCRIPTION
A PR that heavily rely on what has been done in https://github.com/break-stuff/cem-tools/pull/94 that hasn't moved for over a year.

It implements the same feature, in a simpler way now that the hard part of resolving paths can be done by the user using https://wc-toolkit.com/documentation/module-path-resolver/