### PR TITLE
Toggle the use of use imperativeHandle

### DIFF
--- a/tools/configurations/src/config.ts
+++ b/tools/configurations/src/config.ts
@@ -25,6 +25,8 @@ export interface BaseOptions {
   hideLogs?: boolean;
   /** Prevents plugin from executing */
   skip?: boolean;
+  /** Toggle the use of `useImperativeHandle` which alters the `ref` so we can access methods from the custom element. */
+  withImperativeHandle?: boolean;
 }
 
 export interface DescriptionLabels {
@@ -51,6 +53,7 @@ export const baseConfig: BaseOptions = {
     cssParts: "CSS Parts",
     methods: "Methods",
   },
+  withImperativeHandle: undefined,
 };
 
 type ExtendedConfiguration = BaseOptions & { [key: string]: any };

--- a/tools/configurations/src/config.ts
+++ b/tools/configurations/src/config.ts
@@ -25,8 +25,6 @@ export interface BaseOptions {
   hideLogs?: boolean;
   /** Prevents plugin from executing */
   skip?: boolean;
-  /** Toggle the use of `useImperativeHandle` which alters the `ref` so we can access methods from the custom element. */
-  withImperativeHandle?: boolean;
 }
 
 export interface DescriptionLabels {
@@ -53,7 +51,6 @@ export const baseConfig: BaseOptions = {
     cssParts: "CSS Parts",
     methods: "Methods",
   },
-  withImperativeHandle: undefined,
 };
 
 type ExtendedConfiguration = BaseOptions & { [key: string]: any };


### PR DESCRIPTION
The goal is to allow users to create wrappers with a specific behavior for `useRef` by toggling the application of 'useImperativeHandle'. 

This PR does three things:

1. Adds the config option `withImperativeHandle`
2. Using the option to omit the `useImperativeHandle` feature so that users can retrieve the custom element from `ref.current`. 
3. The `useImperativeHandle` when used, now gets a 'customElement' property as a fallback to retrieve the custom element. 